### PR TITLE
Ftp for netapp

### DIFF
--- a/packages/web/lib/fog/fogftp.class.php
+++ b/packages/web/lib/fog/fogftp.class.php
@@ -214,7 +214,8 @@ class FOGFTP extends FOGGetSet
                     $timeout = $this->get('timeout');
                 }
             }
-            $this->_link = $connectmethod($host, $port, $timeout);
+            //$this->_link = $connectmethod($host, $port, $timeout);
+            $this->_link = $connectmethod($_SERVER['SERVER_ADDR'], $port, $timeout); //CES_CUSTOMIZATION GET Host By its current IP
             if ($this->_link === false) {
                 trigger_error(_('FTP connection failed'), E_USER_NOTICE);
                 $this->ftperror($this->data);

--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -57,6 +57,6 @@ class System
         define('FOG_SCHEMA', 270);
         define('FOG_BCACHE_VER', 135);
         define('FOG_CLIENT_VERSION', '0.12.0');
-        define('FOG_VERSION_CES', '1.5.9.20220328');
+        define('FOG_VERSION_CES', '1.5.9.20220504');
     }
 }


### PR DESCRIPTION
To support FTP Service for NetApp by using local FOG server FTP Service.

Remarks: 
- Will break storage node behaviors.
- NetApp with Linux mode.